### PR TITLE
Update Get Issues Request

### DIFF
--- a/gitlab-stats.js
+++ b/gitlab-stats.js
@@ -229,7 +229,7 @@ async function getAsset(name) {
 
 async function fetchData() {
   let resp = await new Request(
-    `${GITLAB_URL}/api/v4/issues?state=opened&scope=assigned_to_me&private_token=${ACCESS_TOKEN}`
+    `${GITLAB_URL}/api/v4/issues?state=opened&scope=assigned_to_me&per_page=100&private_token=${ACCESS_TOKEN}`
   ).loadJSON();
   const assignedIssueCount = resp.length;
 


### PR DESCRIPTION
Add „per Page“ paramter to „Get Issues“ request and set to highest possible number.

This is a quick fix for only fetching 20 issues (default).

> By default, GET requests return 20 results at a time because the API results are paginated.

* https://docs.gitlab.com/ee/api/issues.html
* https://docs.gitlab.com/ee/api/README.html#pagination

A better solution would be to handle the API pagination properly but maybe one shouldn’t have more than 100 assigned issues in the first place 😉